### PR TITLE
Revert "Fix: Explicitly COPY config/environment.rb in DockerfileAdds a specific COPY instruction in the Dockerfile for`config/environment.rb` before the general `COPY . .` command.This is to ensure this critical file is present in the Docker image,addressing the issue where it was found to be missing during CI runswhen not using the override volume mount."

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Check for config/environment.rb in CI checkout
+        run: |
+          echo "Listing ./ultradex/config on CI runner:"
+          ls -la ./ultradex/config
+          echo "Checking for ./ultradex/config/environment.rb on CI runner:"
+          if [ -f "./ultradex/config/environment.rb" ]; then
+            echo "./ultradex/config/environment.rb FOUND in CI checkout."
+          else
+            echo "CRITICAL: ./ultradex/config/environment.rb NOT FOUND in CI checkout!"
+            exit 1
+          fi
+
       - name: Set up Docker Compose and Build services
         working-directory: ./ultradex
         run: |

--- a/ultradex/Dockerfile
+++ b/ultradex/Dockerfile
@@ -116,9 +116,6 @@ RUN /bin/bash -l -c "bundle install --jobs \"$(nproc)\" --retry 3"
 # and the entrypoint script, ensuring correct ownership and permissions for system locations.
 USER root
 
-# Explicitly copy config/environment.rb to ensure it's present
-COPY --chown=appuser:appuser config/environment.rb ./config/
-
 # Copy the rest of the application code into the container.
 # The --chown flag ensures all application files are owned by appuser.
 COPY --chown=appuser:appuser . .


### PR DESCRIPTION
Reverts elif/ultradex#51